### PR TITLE
getRxStats() does not clear counters if self.rxPkts already exists

### DIFF
--- a/lua/device.lua
+++ b/lua/device.lua
@@ -541,6 +541,10 @@ function dev:resetTimeCounters()
 	self:unsupported("Time counter tracking")
 end
 
+function dev:clearRxStats()
+	return
+end
+
 --- Enable tx timestamps.
 --- @see dev.enableTxTimestamps()
 function txQueue:enableTimestamps()

--- a/lua/driver/ixgbe.lua
+++ b/lua/driver/ixgbe.lua
@@ -50,6 +50,13 @@ function dev:getRxStats()
 	return tonumber(self.rxPkts), tonumber(self.rxBytes)
 end
 
+-- clear RX counters
+function dev:clearRxStats()
+	self.rxPkts = 0ULL
+	self.rxBytes = 0ULL
+	return tonumber(self.rxPkts), tonumber(self.rxBytes)
+end
+
 -- necessary because of clear-on-read registers and the interaction with the normal rte_eth_stats_get() call
 function dev:getTxStats()
 	self.txPkts = (self.txPkts or 0ULL) + dpdkc.read_reg32(self.id, GPTC)

--- a/lua/driver/ixgbe.lua
+++ b/lua/driver/ixgbe.lua
@@ -50,13 +50,14 @@ function dev:getRxStats()
 	return tonumber(self.rxPkts), tonumber(self.rxBytes)
 end
 
--- clear RX counters.  We want to clear the s/w statistics and how reg read to clear the h/w level
+-- clear RX counters.  We want to clear the s/w statistics and also reg read to clear the h/w level
 function dev:clearRxStats()
-	self.rxPkts = dpdkc.read_reg32(self.id, GPRC)
-	self.rxBytes = dpdkc.read_reg32(self.id, GORCL) + dpdkc.read_reg32(self.id, GORCH) * 2^32
+	dpdkc.read_reg32(self.id, GPRC)
+	dpdkc.read_reg32(self.id, GORCL)
+	dpdkc.read_reg32(self.id, GORCH)
 	self.rxPkts = 0ULL
 	self.rxBytes = 0ULL
-	return tonumber(self.rxPkts), tonumber(self.rxBytes)
+	return
 end
 
 -- necessary because of clear-on-read registers and the interaction with the normal rte_eth_stats_get() call

--- a/lua/driver/ixgbe.lua
+++ b/lua/driver/ixgbe.lua
@@ -50,8 +50,10 @@ function dev:getRxStats()
 	return tonumber(self.rxPkts), tonumber(self.rxBytes)
 end
 
--- clear RX counters
+-- clear RX counters.  We want to clear the s/w statistics and how reg read to clear the h/w level
 function dev:clearRxStats()
+	self.rxPkts = dpdkc.read_reg32(self.id, GPRC)
+	self.rxBytes = dpdkc.read_reg32(self.id, GORCL) + dpdkc.read_reg32(self.id, GORCH) * 2^32
 	self.rxPkts = 0ULL
 	self.rxBytes = 0ULL
 	return tonumber(self.rxPkts), tonumber(self.rxBytes)

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -273,6 +273,7 @@ function mod:newDevRxCounter(name, dev, format, file)
 	obj.sleep = 100
 	setmetatable(obj, devRxCounter)
 	obj:getThroughput() -- reset stats on the NIC
+	obj:clearThroughput()
 	return obj
 end
 
@@ -323,6 +324,10 @@ end
 function devRxCounter:getThroughput() 
     return self.dev:getRxStats() 
 end 
+
+function devRxCounter:clearThroughput() 
+    return self.dev:clearRxStats() 
+end
 
 --- Packet-based counter
 function pktRxCounter:countPacket(buf)

--- a/lua/stats.lua
+++ b/lua/stats.lua
@@ -272,8 +272,7 @@ function mod:newDevRxCounter(name, dev, format, file)
 	local obj = newCounter("dev", name, dev, format, file)
 	obj.sleep = 100
 	setmetatable(obj, devRxCounter)
-	obj:getThroughput() -- reset stats on the NIC
-	obj:clearThroughput()
+	obj:clearThroughput() -- reset stats on the NIC
 	return obj
 end
 


### PR DESCRIPTION
We have witnessed inaccurate Rx packet counter statistics when Rx packet counters already exist.

dev:getRxStats()

will not clear the Rx counters if self.rxPkts is not 'nil'.

This pull request adds a function clearThroughput that will clear both hardware and software Rx counters.