### PR TITLE
Flags for compiling on Debian Buster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ SET(FILES
 	src/timestamping_i40e
 	src/timestamping_ixgbe
 	src/timestamping_igb
+	src/bytesizedring
+	src/pktsizedring
 )
 
 SET(DPDK_LIBS

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,7 @@ fi
 if ${MLX4} ; then
 	sed -ri 's,(MLX4_PMD=).*,\1y,' x86_64-native-linuxapp-gcc/.config
 fi
+export EXTRA_CFLAGS="-Wno-stringop-overflow -Wno-cast-function-type -Wno-array-bounds -Wno-stringop-truncation -Wno-format-overflow"
 make -j $NUM_CPUS O=x86_64-native-linuxapp-gcc
 )
 

--- a/lua/dpdkc.lua
+++ b/lua/dpdkc.lua
@@ -240,7 +240,7 @@ ffi.cdef[[
 
 	// memory
 	struct mempool* init_mem(uint32_t nb_mbuf, uint32_t sock, uint32_t mbuf_size);
-	struct rte_mbuf* alloc_mbuf(struct mempool* mp);
+	struct rte_mbuf* rte_pktmbuf_alloc_export(struct mempool* mp);
 	void alloc_mbufs(struct mempool* mp, struct rte_mbuf* bufs[], uint32_t len, uint16_t pkt_len);
 	void rte_pktmbuf_free_export(struct rte_mbuf* m);
 	uint16_t rte_mbuf_refcnt_read_export(struct rte_mbuf* m);

--- a/lua/dpdkc.lua
+++ b/lua/dpdkc.lua
@@ -245,6 +245,8 @@ ffi.cdef[[
 	void rte_pktmbuf_free_export(struct rte_mbuf* m);
 	uint16_t rte_mbuf_refcnt_read_export(struct rte_mbuf* m);
 	uint16_t rte_mbuf_refcnt_update_export(struct rte_mbuf* m, int16_t value);
+	char *rte_pktmbuf_adj_export(struct rte_mbuf *m, uint16_t len);
+	int rte_pktmbuf_trim_export(struct rte_mbuf *m, uint16_t len);
 
 	// devices
 	int rte_pci_probe();

--- a/lua/driver/igb.lua
+++ b/lua/driver/igb.lua
@@ -24,6 +24,7 @@ local SYSTIMEL   = 0x0000B600
 local SYSTIMEH   = 0x0000B604
 local TIMEADJL   = 0x0000B60C
 local TIMEADJH   = 0x0000B610
+local SRRCTL_TIMESTAMP = 0x40000000
 
 local SRRCTL_82580 = {}
 for i = 0, 7 do

--- a/lua/memory.lua
+++ b/lua/memory.lua
@@ -245,8 +245,10 @@ end
 
 function mempool:alloc(l)
 	local r = dpdkc.rte_pktmbuf_alloc_export(self)
-	r.pkt_len = l
-	r.data_len = l
+	if r ~= nil then
+		r.pkt_len = l
+		r.data_len = l
+	end
 	return r
 end
 

--- a/lua/memory.lua
+++ b/lua/memory.lua
@@ -244,7 +244,7 @@ function mempool:retain()
 end
 
 function mempool:alloc(l)
-	local r = dpdkc.alloc_mbuf(self)
+	local r = dpdkc.rte_pktmbuf_alloc_export(self)
 	r.pkt_len = l
 	r.data_len = l
 	return r

--- a/lua/packet.lua
+++ b/lua/packet.lua
@@ -151,6 +151,14 @@ function pkt:free()
 	dpdkc.rte_pktmbuf_free_export(self)
 end
 
+function pkt:removeFirst(bytes)
+	dpdkc.rte_pktmbuf_adj_export(self, bytes)
+end
+
+function pkt:removeLast(bytes)
+	dpdkc.rte_pktmbuf_trim_export(self, bytes)
+end
+
 -------------------------------------------------------------------------------------------------------
 ---- IPSec offloading
 -------------------------------------------------------------------------------------------------------

--- a/src/bytesizedring.cpp
+++ b/src/bytesizedring.cpp
@@ -18,7 +18,7 @@ struct bs_ring* create_bsring(uint32_t capacity, int32_t socket) {
 		count *= 2;
 	}
 	char ring_name[32];
-	struct bs_ring* bsr = (struct bs_ring*)malloc(sizeof(struct bs_ring*));
+	struct bs_ring* bsr = (struct bs_ring*)malloc(sizeof(struct bs_ring));
 	bsr->capacity = capacity;
 	sprintf(ring_name, "mbuf_bs_ring%d", __sync_fetch_and_add(&ring_cnt, 1));
 	bsr->ring = rte_ring_create(ring_name, count, socket, RING_F_SP_ENQ | RING_F_SC_DEQ);

--- a/src/bytesizedring.cpp
+++ b/src/bytesizedring.cpp
@@ -1,0 +1,158 @@
+#include <rte_config.h>
+#include <rte_common.h>
+#include <rte_ring.h>
+#include <stdio.h>
+#include "bytesizedring.hpp"
+
+// DPDK SPSC bounded ring buffer
+/*
+ * This wraps the DPDK SPSC bounded ring buffer into a structure whose capacity
+ * limits the number of bytes it can hold.
+ */
+
+struct bs_ring* create_bsring(uint32_t capacity, int32_t socket) {
+	static volatile uint32_t ring_cnt = 0;
+	int count_min = capacity/60;
+	int count = 1;
+	while (count < count_min && count <= BS_RING_SIZE_LIMIT) {
+		count *= 2;
+	}
+	char ring_name[32];
+	struct bs_ring* bsr = (struct bs_ring*)malloc(sizeof(struct bs_ring*));
+	bsr->capacity = capacity;
+	sprintf(ring_name, "mbuf_bs_ring%d", __sync_fetch_and_add(&ring_cnt, 1));
+	bsr->ring = rte_ring_create(ring_name, count, socket, RING_F_SP_ENQ | RING_F_SC_DEQ);
+	bsr->bytes_used = 0;
+
+	if (! bsr->ring) {
+		free(bsr);
+		return NULL;
+	}
+	return bsr;
+}
+
+int bsring_enqueue_bulk(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n) {
+	uint32_t num_added = 0;
+
+	// in bulk mode we either add all or nothing.
+	// check if there is space available.
+	uint32_t i = 0;
+	uint32_t total_size = 0;
+	for (i=0; i<n; i++) {
+		total_size += obj[i]->pkt_len;
+	}
+	if ((bsr->bytes_used + total_size) > bsr->capacity) {
+		return 0;
+	}
+
+	// there should be space available.  Do a bulk enqueue.
+	num_added = rte_ring_sp_enqueue_bulk(bsr->ring, (void**)obj, n, NULL);
+
+	// adjust the bsring's usage values
+	total_size = 0;
+	for (i=0; i<num_added; i++) {
+		total_size += obj[i]->pkt_len;
+	}
+
+	bsr->bytes_used += total_size;
+	return num_added;
+}
+
+int bsring_enqueue_burst(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n) {
+	uint32_t num_to_add = 0;
+	uint32_t num_added = 0;
+	uint32_t bytes_added = 0;
+	
+	// in burst mode we add as many packets as will fit.
+	// count how many packets we can add from the start of this batch.
+	uint32_t i = 0;
+	int bytes_remaining = bsr->capacity - bsr->bytes_used;
+	while ((i < n) && (bytes_remaining > 0)) {
+		bytes_remaining -= (obj[i]->pkt_len);
+		num_to_add++;
+		i++;
+	}
+	if (bytes_remaining < 0) {
+		num_to_add--;
+	}
+	
+	num_added = rte_ring_sp_enqueue_burst(bsr->ring, (void**)obj, num_to_add, NULL);
+	for (i=0; i<num_added; i++) {
+		bytes_added += (obj[i]->pkt_len);
+	}
+
+	// it's possible that some of the remaining packets are small enough
+	// to fit into the remaining space.  Try them iteratively.
+	if (num_added < n) {
+		bytes_remaining = bsr->capacity - bsr->bytes_used - bytes_added;
+		i = num_to_add;
+		while ((i < n) && (bytes_remaining >= 60)) {
+			if ((int)(obj[i]->pkt_len) <= bytes_remaining) {
+				if (rte_ring_sp_enqueue(bsr->ring, obj[i])) {
+					num_added++;
+					bytes_added += (obj[i]->pkt_len);
+					bytes_remaining -= (obj[i]->pkt_len);
+				}
+			}
+			i++;
+		}
+	}
+	
+	bsr->bytes_used += bytes_added;
+	return num_added;
+}
+
+int bsring_enqueue(struct bs_ring* bsr, struct rte_mbuf* obj) {
+	if ((bsr->bytes_used + obj->pkt_len) < bsr->capacity) {
+		if (rte_ring_sp_enqueue(bsr->ring, obj) == 0) {
+			bsr->bytes_used += (obj->pkt_len);
+			return 1;
+		} else {
+			printf("bsring_enqueue(): rte_ring_sp_enqueue failed\n");
+		}
+	}
+	return 0;
+}
+
+int bsring_dequeue_burst(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n) {
+	uint32_t num_dequeued = rte_ring_sc_dequeue_burst(bsr->ring, (void**)obj, n, NULL);
+	uint32_t i = 0;
+	if (num_dequeued > 0) {
+		for (i=0; i<num_dequeued; i++) {
+			bsr->bytes_used -= (obj[i]->pkt_len);
+		}
+	}
+	return num_dequeued;
+}
+
+int bsring_dequeue_bulk(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n) {
+	uint32_t num_dequeued = rte_ring_sc_dequeue_bulk(bsr->ring, (void**)obj, n, NULL);
+	uint32_t i = 0;
+	if (num_dequeued > 0) {
+		for (i=0; i<num_dequeued; i++) {
+			bsr->bytes_used -= (obj[i]->pkt_len);
+		}
+	}
+	return num_dequeued;
+}
+
+int bsring_dequeue(struct bs_ring* bsr, struct rte_mbuf** obj) {
+	if (rte_ring_sc_dequeue(bsr->ring, (void**)obj) == 0) {
+		bsr->bytes_used -= (obj[0]->pkt_len);
+		return 1;
+	}
+	return 0;
+}
+
+int bsring_count(struct bs_ring* bsr) {
+	return rte_ring_count(bsr->ring);
+}
+
+int bsring_capacity(struct bs_ring* bsr) {
+	return bsr->capacity;
+}
+
+int bsring_bytesused(struct bs_ring* bsr) {
+	return bsr->bytes_used;
+}
+

--- a/src/bytesizedring.hpp
+++ b/src/bytesizedring.hpp
@@ -1,0 +1,68 @@
+#ifndef MG_BYTESIZEDRING_H
+#define MG_BYTESIZEDRING_H
+
+#include <cstdint>
+#include <atomic>
+
+#include <rte_config.h>
+#include <rte_common.h>
+#include <rte_ring.h>
+#include <rte_mbuf.h>
+//#include <rte_rwlock.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BS_RING_SIZE_LIMIT 268435455
+
+struct bs_ring
+{
+	struct rte_ring* ring;
+	uint32_t capacity;
+
+	/*
+	 * Keep track of the number of bytes in the ring buffer.
+	 * This value is an atomic because it will be modified by
+	 * multiple threads.  It is used in a simple way to
+	 * maintain better performance.  Therefore it is possible to
+	 * read this value in a transient state where its value
+	 * is briefly out of sync with the contents of the buffer.
+	 * If there are multiple threads feeding the buffer, this
+	 * could result in filling the buffer above its intended
+	 * capacity.
+	 *
+	 * TODO:
+	 * We could provide better protection by locking over the
+	 * entire enqueue/dequeue functions, but expect performance
+	 * to suffer.
+	 */
+	std::atomic<uint32_t> bytes_used;
+};
+
+struct bs_ring* create_bsring(uint32_t capacity, int32_t socket);
+
+/**
+ * The difference between bulk and burst is when n>1.  In those
+ * cases bulk mode will only en/dequeue a full batch.  In burst
+ * mode it will enqueue whatever there is space for, or dequeue
+ * as many as are available, up to n.
+ */
+int bsring_enqueue_bulk(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n);
+int bsring_enqueue_burst(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n);
+int bsring_enqueue(struct bs_ring* bsr, struct rte_mbuf* obj);
+int bsring_dequeue_bulk(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n);
+int bsring_dequeue_burst(struct bs_ring* bsr, struct rte_mbuf** obj, uint32_t n);
+int bsring_dequeue(struct bs_ring* bsr, struct rte_mbuf** obj);
+int bsring_count(struct bs_ring* bsr);
+int bsring_capacity(struct bs_ring* bsr);
+int bsring_bytesused(struct bs_ring* bsr);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/src/device.c
+++ b/src/device.c
@@ -119,8 +119,9 @@ int dpdk_configure_device(struct libmoon_device_config* cfg) {
 			.header_split = 0,
 			.hw_ip_checksum = !cfg->disable_offloads,
 			.hw_vlan_filter = 0,
-			.jumbo_frame = 0,
+			.jumbo_frame = 1,
 			.hw_strip_crc = 1,
+			.max_rx_pkt_len= 9218,
 			.hw_vlan_strip = cfg->strip_vlan ? 1 : 0,
 		},
 		.txmode = {

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,9 +28,8 @@ struct rte_mempool* init_mem(uint32_t nb_mbuf, uint32_t socket, uint32_t mbuf_si
 	return pool;
 }
 
-struct rte_mbuf* alloc_mbuf(struct rte_mempool* mp) {
-	struct rte_mbuf* res = rte_pktmbuf_alloc(mp);
-	return res;
+struct rte_mbuf* rte_pktmbuf_alloc_export(struct rte_mempool* mp) {
+	return rte_pktmbuf_alloc(mp);
 }
 
 void alloc_mbufs(struct rte_mempool* mp, struct rte_mbuf* bufs[], uint32_t len, uint16_t pkt_len) {

--- a/src/memory.c
+++ b/src/memory.c
@@ -81,6 +81,14 @@ uint16_t rte_mbuf_refcnt_update_export(struct rte_mbuf* m, int16_t value) {
 	return rte_mbuf_refcnt_update(m, value);
 }
 
+char *rte_pktmbuf_adj_export(struct rte_mbuf *m, uint16_t len) {
+	return rte_pktmbuf_adj(m, len);
+}
+
+int rte_pktmbuf_trim_export(struct rte_mbuf *m, uint16_t len) {
+	return rte_pktmbuf_trim(m, len);
+}
+
 
 void* alloc_huge(size_t size) {
 	void* mem = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_NORESERVE | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/src/pcap.cpp
+++ b/src/pcap.cpp
@@ -20,7 +20,7 @@ extern "C" {
 		dst->ts_sec = ts_sec;
 		dst->ts_usec = ts_usec;
 		dst->incl_len = len;
-		dst->orig_len = len;
+		dst->orig_len = orig_len;
 		memcpy(&dst->data, packet, len);
 	}
 

--- a/src/pktsizedring.cpp
+++ b/src/pktsizedring.cpp
@@ -1,0 +1,80 @@
+#include <rte_config.h>
+#include <rte_common.h>
+#include <rte_ring.h>
+#include <rte_rwlock.h>
+#include <stdio.h>
+#include "pktsizedring.hpp"
+
+// DPDK SPSC bounded ring buffer
+/*
+ * This wraps the DPDK SPSC bounded ring buffer into a structure whose capacity
+ * limits the number of packets/frames it can hold.
+ * In the plain implementation the ring size must be a power of 2.
+ */
+
+struct ps_ring* create_psring(uint32_t capacity, int32_t socket) {
+	static volatile uint32_t ring_cnt = 0;
+	if (capacity > PS_RING_SIZE_LIMIT) {
+		printf("WARNING: requested capacity of %d is too large.  Allocating ring of size %d.\n",capacity,PS_RING_SIZE_LIMIT);
+		capacity = PS_RING_SIZE_LIMIT;
+	}
+	uint32_t count = 1;
+	while (count < capacity) {
+		count *= 2;
+	}
+	char ring_name[32];
+	struct ps_ring* psr = (struct ps_ring*)malloc(sizeof(struct ps_ring*));
+	psr->capacity = capacity;
+	sprintf(ring_name, "mbuf_ps_ring%d", __sync_fetch_and_add(&ring_cnt, 1));
+	psr->ring = rte_ring_create(ring_name, count, socket, RING_F_SP_ENQ | RING_F_SC_DEQ);
+	if (! psr->ring) {
+		free(psr);
+		return NULL;
+	}
+	return psr;
+}
+
+int psring_enqueue_bulk(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n) {
+	if ((rte_ring_count(psr->ring) + n) < psr->capacity) {
+		return rte_ring_sp_enqueue_bulk(psr->ring, (void**)obj, n, NULL);
+	}
+	return 0;
+}
+
+int psring_enqueue_burst(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n) {
+	uint32_t count = rte_ring_count(psr->ring);
+	if (count > psr->capacity) {
+		// pktsized ring is over capacity
+		return 0;
+	}
+	uint32_t num_to_add = ((count + n) > psr->capacity) ? (psr->capacity - count) : n;
+	return rte_ring_sp_enqueue_burst(psr->ring, (void**)obj, num_to_add, NULL);
+}
+
+int psring_enqueue(struct ps_ring* psr, struct rte_mbuf* obj) {
+	if ((rte_ring_count(psr->ring) + 1) <= psr->capacity) {
+		return (rte_ring_sp_enqueue(psr->ring, obj) == 0);
+	}
+	return 0;
+}
+
+int psring_dequeue_bulk(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n) {
+	return rte_ring_sc_dequeue_bulk(psr->ring, (void**)obj, n, NULL);
+}
+
+int psring_dequeue_burst(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n) {
+	return rte_ring_sc_dequeue_burst(psr->ring, (void**)obj, n, NULL);
+}
+
+int psring_dequeue(struct ps_ring* psr, struct rte_mbuf** obj) {
+	return (rte_ring_sc_dequeue(psr->ring, (void**)obj) == 0);
+}
+
+int psring_count(struct ps_ring* psr) {
+	return rte_ring_count(psr->ring);
+}
+
+int psring_capacity(struct ps_ring* psr) {
+	return psr->capacity;
+}
+

--- a/src/pktsizedring.cpp
+++ b/src/pktsizedring.cpp
@@ -23,7 +23,7 @@ struct ps_ring* create_psring(uint32_t capacity, int32_t socket) {
 		count *= 2;
 	}
 	char ring_name[32];
-	struct ps_ring* psr = (struct ps_ring*)malloc(sizeof(struct ps_ring*));
+	struct ps_ring* psr = (struct ps_ring*)malloc(sizeof(struct ps_ring));
 	psr->capacity = capacity;
 	sprintf(ring_name, "mbuf_ps_ring%d", __sync_fetch_and_add(&ring_cnt, 1));
 	psr->ring = rte_ring_create(ring_name, count, socket, RING_F_SP_ENQ | RING_F_SC_DEQ);

--- a/src/pktsizedring.hpp
+++ b/src/pktsizedring.hpp
@@ -1,0 +1,47 @@
+#ifndef MG_PKTSIZEDRING_H
+#define MG_PKTSIZEDRING_H
+
+#include <cstdint>
+
+#include <rte_config.h>
+#include <rte_common.h>
+#include <rte_ring.h>
+#include <rte_mbuf.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PS_RING_SIZE_LIMIT 268435455
+
+struct ps_ring
+{
+	struct rte_ring* ring;
+	uint32_t capacity;
+};
+
+struct ps_ring* create_psring(uint32_t capacity, int32_t socket);
+
+/**
+ * The difference between bulk and burst is when n>1.  In those
+ * cases bulk mode will only en/dequeue a full batch.  In burst
+ * mode it will enqueue whatever there is space for, or dequeue
+ * as many as are available, up to n.
+ */
+int psring_enqueue_bulk(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n);
+int psring_enqueue_burst(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n);
+int psring_enqueue(struct ps_ring* psr, struct rte_mbuf* obj);
+int psring_dequeue_bulk(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n);
+int psring_dequeue_burst(struct ps_ring* psr, struct rte_mbuf** obj, uint32_t n);
+int psring_dequeue(struct ps_ring* psr, struct rte_mbuf** obj);
+int psring_count(struct ps_ring* psr);
+int psring_capacity(struct ps_ring* psr);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/src/ring.h
+++ b/src/ring.h
@@ -12,6 +12,7 @@ extern "C" {
 struct rte_ring* create_ring(uint32_t count, int32_t socket);
 int ring_enqueue(struct rte_ring* r, void* const* obj, int n);
 int ring_dequeue(struct rte_ring* r, void** obj, int n);
+int ring_count(struct rte_ring* r);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The GCC version (8.3.0) on Debian Buster seems to have a number of issues with the version of DPDK embedded in libmoon. This PR adds flags that allow the compilation to succeed.